### PR TITLE
Set constraint on ipykernel version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
   run:
     - autovizwidget >=0.6
     - hdijupyterutils >=0.6
-    - ipykernel
+    - ipykernel >=4.2.2,<6.0.0
     - ipython >=4.0.2
     - ipywidgets >5.0.0
     - notebook >=4.2


### PR DESCRIPTION
as it was done in
https://github.com/jupyter-incubator/sparkmagic/commit/260e16ed1d14cbbf020d063f1c65dea2edb722fe

See change log:
https://github.com/jupyter-incubator/sparkmagic/blob/master/CHANGELOG.md#0191

I didn't bump the version because at the moment the Conda package v0.19.1 behaves differently then the equivalent pip package due to this mismatch in dependencies.